### PR TITLE
Grammars from general python types

### DIFF
--- a/guidance/_json_schema_to_grammar.py
+++ b/guidance/_json_schema_to_grammar.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Any
 
 from ._grammar import Byte, GrammarFunction, Join, Select, select
 from .library._char_range import char_range
@@ -58,9 +58,9 @@ def _process_number() -> GrammarFunction:
     )
 
 def _process_object(
-    schema_properties: Union[Dict[str, any], None],
-    additional_properties: Union[Dict[str, any], None],
-    definitions: Union[Dict[str, any], None]
+    schema_properties: Union[Dict[str, Any], None],
+    additional_properties: Union[Dict[str, Any], None],
+    definitions: Union[Dict[str, Any], None]
 ) -> GrammarFunction:
     properties = []
     additional = None
@@ -84,8 +84,8 @@ def _process_object(
     return Join([_OPEN_BRACE, _CLOSE_BRACE])
 
 def _process_properties(
-    schema_properties: Dict[str, any],
-    definitions: Union[Dict[str, any], None]
+    schema_properties: Dict[str, Any],
+    definitions: Union[Dict[str, Any], None]
 ):
     properties = []
     for name, nxt_node in schema_properties.items():
@@ -102,8 +102,8 @@ def _process_properties(
     return properties
 
 def _process_additional_properties(
-    additional_properties: Dict[str, any],
-    definitions: Union[Dict[str, any], None]
+    additional_properties: Dict[str, Any],
+    definitions: Union[Dict[str, Any], None]
 ):
     s = Select([], recursive=True)
     nxt = Join(
@@ -117,7 +117,7 @@ def _process_additional_properties(
     return s
 
 def _process_array(
-    item_node: Dict[str, any], definitions: Union[Dict[str, any], None]
+    item_node: Dict[str, Any], definitions: Union[Dict[str, Any], None]
 ) -> GrammarFunction:
     return Join(
         [
@@ -139,7 +139,7 @@ def _process_array(
     )
 
 
-def _get_definition(reference: str, definitions: Dict[str, any]) -> Dict[str, any]:
+def _get_definition(reference: str, definitions: Dict[str, Any]) -> Dict[str, Any]:
     assert definitions is not None
     REF_START = "#/$defs/"
     assert reference.startswith(
@@ -151,7 +151,7 @@ def _get_definition(reference: str, definitions: Dict[str, any]) -> Dict[str, an
 
 
 def _process_anyOf(
-    options: List[Dict[str, any]], definitions: Dict[str, any]
+    options: List[Dict[str, Any]], definitions: Dict[str, Any]
 ) -> GrammarFunction:
     all_opts = []
     for opt in options:
@@ -160,7 +160,7 @@ def _process_anyOf(
 
 
 def _process_node(
-    node: Dict[str, any], definitions: Union[Dict[str, any], None]
+    node: Dict[str, Any], definitions: Union[Dict[str, Any], None]
 ) -> GrammarFunction:
     ANYOF_STRING = "anyOf"
     if ANYOF_STRING in node:
@@ -199,7 +199,7 @@ def _process_node(
         raise ValueError(f"Unsupported type in schema: {node['type']}")
 
 
-def _json_schema_obj_to_grammar(schema_obj: Dict[str, any]) -> GrammarFunction:
+def _json_schema_obj_to_grammar(schema_obj: Dict[str, Any]) -> GrammarFunction:
     _DEFS_KEY = "$defs"
 
     definitions = None

--- a/guidance/_json_schema_to_grammar.py
+++ b/guidance/_json_schema_to_grammar.py
@@ -158,6 +158,14 @@ def _process_anyOf(
         all_opts.append(_process_node(opt, definitions))
     return select(options=all_opts)
 
+def _process_enum(options: list[Any]):
+    # Should we narrow type annotation or use compact json.dumps?
+    all_opts = []
+    for opt in options:
+        all_opts.append(
+            json.dumps(opt)
+        )
+    return select(options=all_opts)
 
 def _process_node(
     node: Dict[str, Any], definitions: Union[Dict[str, Any], None]
@@ -170,6 +178,8 @@ def _process_node(
     if REF_STRING in node:
         node = _get_definition(node[REF_STRING], definitions)
 
+    if "enum" in node:
+        return _process_enum(node["enum"])
     if node["type"] == "null":
         # Not completely sure about this
         return Select(["null"])

--- a/guidance/_pydantic_to_grammar.py
+++ b/guidance/_pydantic_to_grammar.py
@@ -13,3 +13,11 @@ def pydantic_model_to_grammar(
     json_schema = model.model_json_schema()
 
     return _json_schema_obj_to_grammar(json_schema)
+
+def type_to_grammar(
+    type: type | pydantic.BaseModel | None
+) -> GrammarFunction:
+    adapter = pydantic.TypeAdapter(type)
+    json_schema = adapter.json_schema()
+
+    return _json_schema_obj_to_grammar(json_schema)

--- a/tests/test_json_schema_to_grammar.py
+++ b/tests/test_json_schema_to_grammar.py
@@ -1,7 +1,7 @@
 import json
 
 import pytest
-from jsonschema import validate
+from jsonschema import validate, ValidationError
 
 from guidance import models
 from guidance._grammar import GrammarFunction
@@ -637,6 +637,37 @@ def test_properties_and_additional_properties(target_obj):
     target_string = to_compact_json(target_obj)
     check_string_with_grammar(target_string, grammar)
 
+@pytest.mark.parametrize("target_obj", [1,"2",3])
+def test_enum(target_obj):
+    schema = """{
+    "enum": [1,"2",3]
+}
+"""
+    # First sanity check what we're setting up
+    schema_obj = json.loads(schema)
+    validate(instance=target_obj, schema=schema_obj)
+
+    grammar = json_schema_to_grammar(schema)
+
+    target_string = to_compact_json(target_obj)
+    check_string_with_grammar(target_string, grammar)
+
+@pytest.mark.parametrize("target_obj", [4, '5', True])
+def test_enum_negative_examples(target_obj):
+    schema = """{
+    "enum": [1,"2",3]
+}
+"""
+    # First sanity check what we're setting up
+    schema_obj = json.loads(schema)
+    with pytest.raises(ValidationError):
+        validate(instance=target_obj, schema=schema_obj)
+
+    grammar = json_schema_to_grammar(schema)
+
+    target_string = to_compact_json(target_obj)
+    with pytest.raises(ParserException):
+        check_string_with_grammar(target_string, grammar)
 
 def test_with_mock_model():
     schema = """{

--- a/tests/test_json_schema_to_grammar.py
+++ b/tests/test_json_schema_to_grammar.py
@@ -577,6 +577,66 @@ def test_anyOf_objects(target_obj):
     target_string = to_compact_json(target_obj)
     check_string_with_grammar(target_string, grammar)
 
+@pytest.mark.parametrize("target_obj", [{}, {'a': 1}, {'a':1, 'b':2}])
+def test_simple_additional_properties(target_obj):
+    schema = """{
+    "type": "object",
+    "additionalProperties": {
+            "type" : "integer"
+        }
+    }
+"""
+    # First sanity check what we're setting up
+    schema_obj = json.loads(schema)
+    validate(instance=target_obj, schema=schema_obj)
+
+    grammar = json_schema_to_grammar(schema)
+
+    target_string = to_compact_json(target_obj)
+    check_string_with_grammar(target_string, grammar)
+
+@pytest.mark.parametrize("target_obj", [{}, {'a': 1}, {'a': '2'}, {'a':1, 'b':'2'}])
+def test_anyOf_additional_properties(target_obj):
+    schema = """{
+    "type": "object",
+    "additionalProperties": {
+            "anyOf": [
+                {"type" : "string"},
+                {"type": "integer"}
+            ]
+        }
+    }
+"""
+    # First sanity check what we're setting up
+    schema_obj = json.loads(schema)
+    validate(instance=target_obj, schema=schema_obj)
+
+    grammar = json_schema_to_grammar(schema)
+
+    target_string = to_compact_json(target_obj)
+    check_string_with_grammar(target_string, grammar)
+
+@pytest.mark.parametrize("target_obj", [{'mystr': 'hello'}, {'mystr': 'hello', 'a': 1}, {'mystr': 'hello', 'a':1, 'b':2}])
+def test_properties_and_additional_properties(target_obj):
+    schema = """{
+    "type": "object",
+    "properties": {
+        "mystr": {"type": "string"}
+    },
+    "additionalProperties": {
+        "type": "integer"
+    }
+}
+"""
+    # First sanity check what we're setting up
+    schema_obj = json.loads(schema)
+    validate(instance=target_obj, schema=schema_obj)
+
+    grammar = json_schema_to_grammar(schema)
+
+    target_string = to_compact_json(target_obj)
+    check_string_with_grammar(target_string, grammar)
+
 
 def test_with_mock_model():
     schema = """{

--- a/tests/test_pydantic_to_grammar.py
+++ b/tests/test_pydantic_to_grammar.py
@@ -1,4 +1,5 @@
-from typing import List, Union
+from typing import List, Union, Literal
+from enum import Enum
 
 import json
 import pydantic
@@ -136,3 +137,19 @@ def test_type_to_grammar_on_model():
     grammar = type_to_grammar(Simple)
     obj = Simple(my_string='hello')
     check_object_with_grammar(obj, grammar)
+
+@pytest.mark.parametrize('target_obj', [True, 2, 'Three'])
+def test_enum(target_obj):
+    class MyEnum(Enum):
+        a = True
+        b = 2
+        c = 'Three'
+
+    grammar = type_to_grammar(MyEnum)
+    check_object_with_grammar(target_obj, grammar)
+
+@pytest.mark.parametrize('target_obj', [True, 2, 'Three'])
+def test_literal(target_obj):
+    type = Literal[True, 2, 'Three']
+    grammar = type_to_grammar(type)
+    check_object_with_grammar(target_obj, grammar)

--- a/tests/test_pydantic_to_grammar.py
+++ b/tests/test_pydantic_to_grammar.py
@@ -109,8 +109,13 @@ def test_dict():
     check_object_with_grammar({'a': 1, 'b': 2}, grammar)
     with pytest.raises(ParserException):
         check_object_with_grammar({'a': '1', 'b': '2'}, grammar)
-    with pytest.raises(ParserException):
-        check_object_with_grammar({1: 1, 2: 2}, grammar)
+
+
+def test_dict_nonstring_keys():
+    # TODO: think about this a bit more -- nonstring keys aren't valid JSON
+    type = dict[int, str]
+    grammar = type_to_grammar(type)
+    check_object_with_grammar({1: 'a', 2: 'b'}, grammar)
 
 
 def test_list_of_models():


### PR DESCRIPTION
Piggybacking on PR https://github.com/guidance-ai/guidance/pull/636.

I added support (with accompanying tests) to generate grammars for builtin (and composed) types (using pydantic to generate schemas) with `type_to_grammar`, which is implemented using pydantic's `TypeAdapter`.

Examples of supported types:
```python
int
str
bool
float
list[int]
bool | None
dict[str, list[int]]
```

Furthermore, the framework is generic enough to support pydantic `BaseModel`s and their compositions with the types above, e.g.
```python
list[Model]
dict[str, Model]
Model | None
```

I didn't remove your `pydantic_model_to_grammar` function, although my implementation of `type_to_grammar` fully supports bare `BaseModels`. Rename and/or consolidate at your discretion :)

Note that making `dict`s work required implementing `additionalProperties`. Pydantic allows dicts with non-string keys, but I don't believe that the grammars will respect that since JSON doesn't support (or have a way to specify) non-string keys. It would be good if we could have a warning for users if we detect that they are trying to do this.
