### PR TITLE
Json guidance functions

### DIFF
--- a/guidance/_pydantic_to_grammar.py
+++ b/guidance/_pydantic_to_grammar.py
@@ -3,7 +3,7 @@ from typing import Union
 import pydantic
 
 from ._grammar import GrammarFunction
-from ._json_schema_to_grammar import _json_schema_obj_to_grammar
+from ._json_schema_to_grammar import json_schema_to_grammar
 
 
 def pydantic_model_to_grammar(
@@ -12,4 +12,4 @@ def pydantic_model_to_grammar(
     # Rather than 'type' I think it should be pydantic._internal._model_construction.ModelMetaclass
     json_schema = model.model_json_schema()
 
-    return _json_schema_obj_to_grammar(json_schema)
+    return json_schema_to_grammar(json_schema)

--- a/tests/test_json_schema_to_grammar.py
+++ b/tests/test_json_schema_to_grammar.py
@@ -8,7 +8,6 @@ from guidance._grammar import GrammarFunction
 from guidance._json_schema_to_grammar import json_schema_to_grammar
 from guidance._parser import ParserException
 
-
 def to_compact_json(target: any) -> str:
     # See 'Compact Encoding':
     # https://docs.python.org/3/library/json.html

--- a/tests/test_json_schema_to_grammar.py
+++ b/tests/test_json_schema_to_grammar.py
@@ -540,6 +540,60 @@ def test_nested_ref():
     check_string_with_grammar(target_string, grammar)
 
 
+@pytest.mark.parametrize(
+    "target_obj",
+    [
+        dict(linked_list=dict(value=1, next=None)),
+        dict(linked_list=dict(value=1, next=dict(value=2, next=None))),
+        dict(linked_list=dict(value=1, next=dict(value=2, next=dict(value=3, next=None)))),
+    ],
+)
+def test_recursive_ref(target_obj):
+    schema = """{
+  "$defs": {
+    "LinkedList": {
+      "properties": {
+        "value": {
+          "title": "Value",
+          "type": "integer"
+        },
+        "next": {
+          "anyOf": [
+            {"$ref": "#/$defs/LinkedList"},
+            {"type": "null"}
+          ]
+        }
+      },
+      "required": [
+        "value",
+        "next"
+      ],
+      "title": "LinkedList",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "linked_list": {
+      "$ref": "#/$defs/LinkedList"
+    }
+  },
+  "required": [
+    "linked_list"
+  ],
+  "title": "ALinkedList",
+  "type": "object"
+}
+"""
+    # First sanity check what we're setting up
+    schema_obj = json.loads(schema)
+    validate(instance=target_obj, schema=schema_obj)
+
+    grammar = json_schema_to_grammar(schema)
+
+    target_string = to_compact_json(target_obj)
+    check_string_with_grammar(target_string, grammar)
+
+
 @pytest.mark.parametrize("target_obj", [123, True])
 def test_anyOf_simple(target_obj):
     schema = """{


### PR DESCRIPTION
I changed all of the functions in `_json_schema_to_grammar.py` to `@guidance` decorated functions, using only public interfaces in the process, as recommended by @slundberg.

Consider this a work in progress, as I haven't quite wrapped my head around how to allow recursion without references to placeholder grammars yet. Hope this saves you some time :)