### PR TITLE
Fix infinite recursion with closures

### DIFF
--- a/guidance/library/_json_schema.py
+++ b/guidance/library/_json_schema.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, MutableMapping, Sequence, Union, Callable
+from typing import Any, Mapping, MutableMapping, Sequence, Optional, Callable
 
 import guidance
 from guidance.library import char_range, one_or_more, optional, zero_or_more

--- a/guidance/library/_json_schema.py
+++ b/guidance/library/_json_schema.py
@@ -7,20 +7,6 @@ from .._grammar import select, GrammarFunction
 
 
 @guidance(stateless=True)
-def _get_definition(
-    lm, reference: str, definitions: Mapping[str, Callable[[], GrammarFunction]],
-):
-    assert definitions is not None
-    REF_START = "#/$defs/"
-    assert reference.startswith(
-        REF_START
-    ), f"Reference {reference} must start with {REF_START}"
-
-    target_name = reference[len(REF_START) :]
-    definition = definitions[target_name]
-    return lm + definition()
-
-@guidance(stateless=True)
 def _gen_json_int(lm):
     return lm + optional("-") + one_or_more(char_range("0", "9"))
 
@@ -155,6 +141,7 @@ def _gen_json(
 
     return lm + result
 
+
 @guidance(stateless=True)
 def gen_json(lm, json_schema: Mapping[str, Any], name: Optional[str] = None):
     _DEFS_KEY = "$defs"
@@ -167,6 +154,7 @@ def gen_json(lm, json_schema: Mapping[str, Any], name: Optional[str] = None):
         name=name
     )
 
+
 def _build_definitions(raw_definitions: Mapping[str, Any]) -> Mapping[str, Callable[[], GrammarFunction]]:
     definitions = {}
 
@@ -178,3 +166,18 @@ def _build_definitions(raw_definitions: Mapping[str, Any]) -> Mapping[str, Calla
 
     definitions = {ref: build_definition(schema) for ref, schema in raw_definitions.items()}
     return definitions
+
+
+@guidance(stateless=True)
+def _get_definition(
+    lm, reference: str, definitions: Mapping[str, Callable[[], GrammarFunction]],
+):
+    assert definitions is not None
+    REF_START = "#/$defs/"
+    assert reference.startswith(
+        REF_START
+    ), f"Reference {reference} must start with {REF_START}"
+
+    target_name = reference[len(REF_START) :]
+    definition = definitions[target_name]
+    return lm + definition()

--- a/guidance/library/_json_schema.py
+++ b/guidance/library/_json_schema.py
@@ -176,7 +176,7 @@ def build_definitions(raw_definitions: Mapping[str, Any]) -> Mapping[str, Callab
 def _build_definition(
         json_schema: Mapping[str, Any],
         definitions: Mapping[str, Callable[[], GrammarFunction]]
-) -> Mapping[str, Callable[[], GrammarFunction]]:
+) -> Callable[[], GrammarFunction]:
     @guidance(stateless=True, dedent=False)
     def closure(lm):
         return lm + _gen_json(json_schema=json_schema, definitions=definitions)

--- a/guidance/library/_json_schema.py
+++ b/guidance/library/_json_schema.py
@@ -156,7 +156,7 @@ def _gen_json(
     return lm + result
 
 @guidance(stateless=True)
-def gen_json(lm, json_schema: Mapping[str, Any], name:str|None=None):
+def gen_json(lm, json_schema: Mapping[str, Any], name: Optional[str] = None):
     _DEFS_KEY = "$defs"
     definitions = {}
     if _DEFS_KEY in json_schema:

--- a/guidance/library/_json_schema.py
+++ b/guidance/library/_json_schema.py
@@ -1,13 +1,14 @@
-from typing import Any, Mapping, MutableMapping, Sequence, Union
+from typing import Any, Mapping, MutableMapping, Sequence, Union, Callable
 
 import guidance
 from guidance.library import char_range, one_or_more, optional, zero_or_more
 
-from .._grammar import select
+from .._grammar import select, GrammarFunction
 
 
+@guidance(stateless=True)
 def _get_definition(
-    reference: str, definitions: Mapping[str, Any]
+    lm, reference: str, definitions: Mapping[str, Callable[[], GrammarFunction]],
 ) -> Mapping[str, any]:
     assert definitions is not None
     REF_START = "#/$defs/"
@@ -16,8 +17,8 @@ def _get_definition(
     ), f"Reference {reference} must start with {REF_START}"
 
     target_name = reference[len(REF_START) :]
-    return definitions[target_name]
-
+    definition = definitions[target_name]
+    return lm + definition()
 
 @guidance(stateless=True)
 def _gen_json_int(lm):
@@ -55,7 +56,7 @@ def _gen_json_object(
     lm,
     *,
     properties: Mapping[str, Any],
-    json_schema_refs: MutableMapping[str, Any],
+    definitions: Mapping[str, Callable[[], GrammarFunction]],
 ):
     lm += "{"
     properties_added = 0
@@ -63,10 +64,9 @@ def _gen_json_object(
         lm += '"' + name + '"'
 
         lm += ":"
-        lm += gen_json(
-            name=None,
+        lm += _gen_json(
             json_schema=property_schema,
-            json_schema_refs=json_schema_refs,
+            definitions=definitions,
         )
         properties_added += 1
         if properties_added < len(properties):
@@ -80,14 +80,14 @@ def _gen_json_array(
     lm,
     *,
     item_schema: Mapping[str, Any],
-    json_schema_refs: MutableMapping[str, Any],
+    definitions: Mapping[str, Callable[[], GrammarFunction]],
 ):
     lm += "["
     lm += optional(
         zero_or_more(
-            gen_json(json_schema=item_schema, json_schema_refs=json_schema_refs) + ","
+            _gen_json(json_schema=item_schema, definitions=definitions) + ","
         )
-        + gen_json(json_schema=item_schema, json_schema_refs=json_schema_refs)
+        + _gen_json(json_schema=item_schema, definitions=definitions)
     )
     lm += "]"
     return lm
@@ -98,44 +98,32 @@ def _process_anyOf(
     lm,
     *,
     anyof_list: Sequence[MutableMapping[str, Any]],
-    json_schema_refs: MutableMapping[str, Any],
+    definitions: Mapping[str, Callable[[], GrammarFunction]],
 ):
     options = [
-        gen_json(json_schema=item, json_schema_refs=json_schema_refs)
+        _gen_json(json_schema=item, definitions=definitions)
         for item in anyof_list
     ]
     return lm + select(options)
 
 
 @guidance(stateless=True)
-def gen_json(
+def _gen_json(
     lm,
-    name: Union[str, None] = None,
-    *,
     json_schema: Mapping[str, Any],
-    json_schema_refs: Union[MutableMapping[str, Any], None] = None,
+    definitions: Mapping[str, Callable[[], GrammarFunction]],
 ):
-    if not json_schema_refs:
-        json_schema_refs = dict()
-
-    _DEFS_KEY = "$defs"
-    if _DEFS_KEY in json_schema:
-        json_schema_refs.update(json_schema[_DEFS_KEY])
-
     ANYOF_STRING = "anyOf"
     if ANYOF_STRING in json_schema:
-        return lm + guidance.capture(
-            _process_anyOf(
-                anyof_list=json_schema[ANYOF_STRING], json_schema_refs=json_schema_refs
-            ),
-            name=name,
+        return lm + _process_anyOf(
+            anyof_list=json_schema[ANYOF_STRING],
+            definitions=definitions
         )
 
     REF_STRING = "$ref"
     object_schema = None
     if REF_STRING in json_schema:
-        target_type = "object"
-        object_schema = _get_definition(json_schema[REF_STRING], json_schema_refs)
+        return lm + _get_definition(json_schema[REF_STRING], definitions)
     else:
         target_type = json_schema["type"]
 
@@ -152,7 +140,7 @@ def gen_json(
         result = _gen_json_string()
     elif target_type == "array":
         result = _gen_json_array(
-            item_schema=json_schema["items"], json_schema_refs=json_schema_refs
+            item_schema=json_schema["items"], definitions=definitions
         )
     elif target_type == "object":
         if object_schema is None:
@@ -160,9 +148,36 @@ def gen_json(
         else:
             object_properties = object_schema["properties"]
         result = _gen_json_object(
-            properties=object_properties, json_schema_refs=json_schema_refs
+            properties=object_properties, definitions=definitions
         )
     else:
         raise ValueError(f"Unsupported type in schema: {json_schema['type']}")
 
-    return lm + guidance.capture(result, name=name)
+    return lm + result
+
+@guidance(stateless=True)
+def gen_json(lm, json_schema: Mapping[str, Any], name:str|None=None):
+    _DEFS_KEY = "$defs"
+    definitions = {}
+    if _DEFS_KEY in json_schema:
+        definitions = build_definitions(json_schema[_DEFS_KEY])
+
+    return lm + guidance.capture(
+        _gen_json(json_schema, definitions),
+        name=name
+    )
+
+def build_definitions(raw_definitions: Mapping[str, Any]) -> Mapping[str, Callable[[], GrammarFunction]]:
+    definitions = {}
+    for ref, schema in raw_definitions.items():
+        definitions[ref] = _build_definition(schema, definitions)
+    return definitions
+
+def _build_definition(
+        json_schema: Mapping[str, Any],
+        definitions: Mapping[str, Callable[[], GrammarFunction]]
+) -> Mapping[str, Callable[[], GrammarFunction]]:
+    @guidance(stateless=True, dedent=False)
+    def closure(lm):
+        return lm + _gen_json(json_schema=json_schema, definitions=definitions)
+    return closure

--- a/guidance/library/_json_schema.py
+++ b/guidance/library/_json_schema.py
@@ -160,14 +160,14 @@ def gen_json(lm, json_schema: Mapping[str, Any], name: Optional[str] = None):
     _DEFS_KEY = "$defs"
     definitions = {}
     if _DEFS_KEY in json_schema:
-        definitions = build_definitions(json_schema[_DEFS_KEY])
+        definitions = _build_definitions(json_schema[_DEFS_KEY])
 
     return lm + guidance.capture(
         _gen_json(json_schema, definitions),
         name=name
     )
 
-def build_definitions(raw_definitions: Mapping[str, Any]) -> Mapping[str, Callable[[], GrammarFunction]]:
+def _build_definitions(raw_definitions: Mapping[str, Any]) -> Mapping[str, Callable[[], GrammarFunction]]:
     definitions = {}
     for ref, schema in raw_definitions.items():
         definitions[ref] = _build_definition(schema, definitions)

--- a/guidance/library/_json_schema.py
+++ b/guidance/library/_json_schema.py
@@ -9,7 +9,7 @@ from .._grammar import select, GrammarFunction
 @guidance(stateless=True)
 def _get_definition(
     lm, reference: str, definitions: Mapping[str, Callable[[], GrammarFunction]],
-) -> Mapping[str, any]:
+):
     assert definitions is not None
     REF_START = "#/$defs/"
     assert reference.startswith(

--- a/guidance/library/_json_schema.py
+++ b/guidance/library/_json_schema.py
@@ -169,15 +169,12 @@ def gen_json(lm, json_schema: Mapping[str, Any], name: Optional[str] = None):
 
 def _build_definitions(raw_definitions: Mapping[str, Any]) -> Mapping[str, Callable[[], GrammarFunction]]:
     definitions = {}
-    for ref, schema in raw_definitions.items():
-        definitions[ref] = _build_definition(schema, definitions)
-    return definitions
 
-def _build_definition(
-        json_schema: Mapping[str, Any],
-        definitions: Mapping[str, Callable[[], GrammarFunction]]
-) -> Callable[[], GrammarFunction]:
-    @guidance(stateless=True, dedent=False)
-    def closure(lm):
-        return lm + _gen_json(json_schema=json_schema, definitions=definitions)
-    return closure
+    def build_definition(json_schema: Mapping[str, Any]) -> Callable[[], GrammarFunction]:
+        @guidance(stateless=True, dedent=False)
+        def closure(lm):
+            return lm + _gen_json(json_schema=json_schema, definitions=definitions)
+        return closure
+
+    definitions = {ref: build_definition(schema) for ref, schema in raw_definitions.items()}
+    return definitions

--- a/tests/library/test_json_schema.py
+++ b/tests/library/test_json_schema.py
@@ -635,7 +635,8 @@ class TestRecursiveStructures:
                         }
                     ]
                 }
-            }
+            },
+            "type": "object"
         }
     },
     "type": "object",


### PR DESCRIPTION
Guidance handles what would otherwise be infinitely recursive calls to guidance functions with a little "placeholder" based lazy-evaluation. This works great when the guidance functions take no arguments, but it fails otherwise. Fixing that may be a nice PR in of itself, but in the meantime, we can put ourselves in the zero-arg setting using closures.

Please take a look and let me know if you want to take some time to discuss this in detail.

P.S. one of your test cases was missing a `"type": "object"`, which I included on the first commit of this branch.